### PR TITLE
chore: rebrand user-facing open-swe to AgentMojo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,25 @@
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="apps/docs/logo/dark.svg">
     <source media="(prefers-color-scheme: light)" srcset="apps/docs/logo/light.svg">
-    <img src="apps/docs/logo/dark.svg" alt="Open SWE Logo" width="35%">
+    <img src="apps/docs/logo/dark.svg" alt="AgentMojo Logo" width="35%">
   </picture>
 </div>
 
 <div align="center">
-  <h1>Open SWE - An Open-Source Asynchronous Coding Agent</h1>
+  <h1>AgentMojo - An Open-Source Asynchronous Coding Agent</h1>
 </div>
 
-Open SWE is an open-source cloud-based asynchronous coding agent built with [LangGraph](https://langchain-ai.github.io/langgraphjs/). It autonomously understands codebases, plans solutions, and executes code changes across entire repositories—from initial planning to opening pull requests.
+AgentMojo is an open-source cloud-based asynchronous coding agent built with [LangGraph](https://langchain-ai.github.io/langgraphjs/). It autonomously understands codebases, plans solutions, and executes code changes across entire repositories—from initial planning to opening pull requests.
 
 > [!TIP]
-> Try out Open SWE yourself using our [public demo](https://swe.langchain.com)!
+> Try out AgentMojo yourself using our [public demo](https://agentmojo.langchain.com)!
 >
 > **Note: you're required to set your own LLM API keys to use the demo.**
 
 > [!NOTE]
-> 📚 See the **Open SWE documentation [here](https://docs.langchain.com/labs/swe/)**
+> 📚 See the **AgentMojo documentation [here](https://docs.langchain.com/labs/agentmojo/)**
 >
-> 💬 Read the **announcement blog post [here](https://blog.langchain.com/introducing-open-swe-an-open-source-asynchronous-coding-agent/)**
+> 💬 Read the **announcement blog post [here](https://blog.langchain.com/introducing-agentmojo-an-open-source-asynchronous-coding-agent/)**
 >
 > 📺 Watch the **announcement video [here](https://youtu.be/TaYVvXbOs8c)**
 
@@ -28,20 +28,20 @@ Open SWE is an open-source cloud-based asynchronous coding agent built with [Lan
 
 ![UI Screenshot](./static/ui-screenshot.png)
 
-- 📝 **Planning**: Open SWE has a dedicated planning step which allows it to deeply understand complex codebases and nuanced tasks. You're also given the ability to accept, edit, or reject the proposed plan before it's executed.
-- 🤝 **Human in the loop**: With Open SWE, you can send it messages while it's running (both during the planning and execution steps). This allows for giving real time feedback and instructions without having to interrupt the process.
-- 🏃 **Parallel Execution**: You can run as many Open SWE tasks as you want in parallel! Since it runs in a sandbox environment in the cloud, you're not limited by the number of tasks you can run at once.
-- 🧑‍💻 **End to end task management**: Open SWE will automatically create GitHub issues for tasks, and create pull requests which will close the issue when implementation is complete.
+- 📝 **Planning**: AgentMojo has a dedicated planning step which allows it to deeply understand complex codebases and nuanced tasks. You're also given the ability to accept, edit, or reject the proposed plan before it's executed.
+- 🤝 **Human in the loop**: With AgentMojo, you can send it messages while it's running (both during the planning and execution steps). This allows for giving real time feedback and instructions without having to interrupt the process.
+- 🏃 **Parallel Execution**: You can run as many AgentMojo tasks as you want in parallel! Since it runs in a sandbox environment in the cloud, you're not limited by the number of tasks you can run at once.
+- 🧑‍💻 **End to end task management**: AgentMojo will automatically create GitHub issues for tasks, and create pull requests which will close the issue when implementation is complete.
 
 
 ## Usage
 
-Open SWE can be used in multiple ways:
+AgentMojo can be used in multiple ways:
 
-- 🖥️ **From the UI**. You can create, manage and execute Open SWE tasks from the [web application](https://swe.langchain.com). See the ['From the UI' page](https://docs.langchain.com/labs/swe/usage/ui) in the docs for more information.
-- 📝 **From GitHub**. You can start Open SWE tasks directly from GitHub issues simply by adding a label `open-swe`, or `open-swe-auto` (adding `-auto` will cause Open SWE to automatically accept the plan, requiring no intervention from you). For enhanced performance on complex tasks, use `open-swe-max` or `open-swe-max-auto` labels which utilize Claude Opus 4.1 for both planning and programming. See the ['From GitHub' page](https://docs.langchain.com/labs/swe/usage/github) in the docs for more information.
+- 🖥️ **From the UI**. You can create, manage and execute AgentMojo tasks from the [web application](https://agentmojo.langchain.com). See the ['From the UI' page](https://docs.langchain.com/labs/agentmojo/usage/ui) in the docs for more information.
+- 📝 **From GitHub**. You can start AgentMojo tasks directly from GitHub issues simply by adding a label `agentmojo`, or `agentmojo-auto` (adding `-auto` will cause AgentMojo to automatically accept the plan, requiring no intervention from you). For enhanced performance on complex tasks, use `agentmojo-max` or `agentmojo-max-auto` labels which utilize Claude Opus 4.1 for both planning and programming. See the ['From GitHub' page](https://docs.langchain.com/labs/agentmojo/usage/github) in the docs for more information.
 
 # Documentation
 
-To get started using Open SWE locally, see the [documentation here](https://docs.langchain.com/labs/swe/).
+To get started using AgentMojo locally, see the [documentation here](https://docs.langchain.com/labs/agentmojo/).
 

--- a/apps/cli/src/TerminalInterface.tsx
+++ b/apps/cli/src/TerminalInterface.tsx
@@ -17,7 +17,7 @@ const TerminalInterface: React.FC<TerminalInterfaceProps> = ({
   return (
     <Box flexDirection="column" padding={1}>
       <Box justifyContent="center" marginBottom={0}>
-        <Text bold>LangChain Open SWE CLI</Text>
+        <Text bold>LangChain AgentMojo CLI</Text>
       </Box>
       <Box flexDirection="column">
         <Text>Describe your coding task in as much detail as possible...</Text>

--- a/apps/cli/src/index.tsx
+++ b/apps/cli/src/index.tsx
@@ -30,8 +30,8 @@ import { TraceReplayService } from "./trace_replay.js";
 const program = new Command();
 
 program
-  .name("open-swe")
-  .description("Open SWE CLI - Local Mode")
+  .name("agentmojo")
+  .description("AgentMojo CLI - Local Mode")
   .version(OPEN_SWE_CLI_VERSION)
   .option("--replay <file>", "Replay from LangSmith trace file")
   .option("--speed <ms>", "Replay speed in milliseconds", "500")

--- a/apps/open-swe/src/graphs/manager/nodes/classify-message/prompts.ts
+++ b/apps/open-swe/src/graphs/manager/nodes/classify-message/prompts.ts
@@ -67,14 +67,14 @@ Your routing options are:
 
 # Additional Context
 You're an open source AI coding agent built by LangChain.
-Your source code is available in the GitHub repository: https://github.com/langchain-ai/open-swe
-The website you're accessible through is: https://swe.langchain.com
-Your documentation is available at: https://docs.langchain.com/labs/swe
+Your source code is available in the GitHub repository: https://github.com/langchain-ai/AgentMojo
+The website you're accessible through is: https://agentmojo.langchain.com
+Your documentation is available at: https://docs.langchain.com/labs/agentmojo
 You can be invoked by both the web app, or by adding a label to a GitHub issue. These label options are:
-- \`open-swe\` - trigger a standard Open SWE task. It will interrupt after generating a plan, and the user must approve it before it can continue. Uses Claude Sonnet 4 for all LLM requests.
-- \`open-swe-auto\` - trigger an 'auto' Open SWE task. It will not interrupt after generating a plan, and instead it will auto-approve the plan, and continue to the programming step without user approval. Uses Claude Sonnet 4 for all LLM requests.
-- \`open-swe-max\` - this label acts the same as \`open-swe\`, except it uses a larger, more powerful model for the planning and programming steps: Claude Opus 4.1. It still uses Claude Sonnet 4 for the reviewer step.
-- \`open-swe-max-auto\` - this label acts the same as \`open-swe-auto\`, except it uses a larger, more powerful model for the planning and programming steps: Claude Opus 4.1. It still uses Claude Sonnet 4 for the reviewer step.
+- \`agentmojo\` - trigger a standard AgentMojo task. It will interrupt after generating a plan, and the user must approve it before it can continue. Uses Claude Sonnet 4 for all LLM requests.
+- \`agentmojo-auto\` - trigger an 'auto' AgentMojo task. It will not interrupt after generating a plan, and instead it will auto-approve the plan, and continue to the programming step without user approval. Uses Claude Sonnet 4 for all LLM requests.
+- \`agentmojo-max\` - this label acts the same as \`agentmojo\`, except it uses a larger, more powerful model for the planning and programming steps: Claude Opus 4.1. It still uses Claude Sonnet 4 for the reviewer step.
+- \`agentmojo-max-auto\` - this label acts the same as \`agentmojo-auto\`, except it uses a larger, more powerful model for the planning and programming steps: Claude Opus 4.1. It still uses Claude Sonnet 4 for the reviewer step.
 
 Only provide this information if requested by the user.
 For example, if the user asks what you can do, you should provide the above information in your response.

--- a/apps/open-swe/src/routes/github/constants.ts
+++ b/apps/open-swe/src/routes/github/constants.ts
@@ -1,3 +1,3 @@
 export const GITHUB_TRIGGER_USERNAME = process.env.GITHUB_TRIGGER_USERNAME
   ? `@${process.env.GITHUB_TRIGGER_USERNAME}`
-  : "@open-swe";
+  : "@agentmojo";

--- a/apps/open-swe/src/routes/github/utils.ts
+++ b/apps/open-swe/src/routes/github/utils.ts
@@ -38,7 +38,7 @@ export function createDevMetadataComment(runId: string, threadId: string) {
 }
 
 export function mentionsGitHubUserForTrigger(commentBody: string): boolean {
-  return /@open-swe\b/.test(commentBody);
+  return /@agentmojo\b/.test(commentBody);
 }
 
 export function extractLinkedIssues(prBody: string): number[] {

--- a/apps/open-swe/src/utils/github/api.ts
+++ b/apps/open-swe/src/utils/github/api.ts
@@ -230,7 +230,7 @@ export async function createPullRequest({
   }
 
   try {
-    logger.info("Adding 'open-swe' label to pull request", {
+    logger.info("Adding 'agentmojo' label to pull request", {
       pullRequestNumber: pullRequest.number,
     });
     await octokit.issues.addLabels({
@@ -239,11 +239,11 @@ export async function createPullRequest({
       issue_number: pullRequest.number,
       labels: [getOpenSWELabel()],
     });
-    logger.info("Added 'open-swe' label to pull request", {
+    logger.info("Added 'agentmojo' label to pull request", {
       pullRequestNumber: pullRequest.number,
     });
   } catch (labelError) {
-    logger.warn("Failed to add 'open-swe' label to pull request", {
+    logger.warn("Failed to add 'agentmojo' label to pull request", {
       pullRequestNumber: pullRequest.number,
       labelError,
     });

--- a/apps/open-swe/src/utils/github/git.ts
+++ b/apps/open-swe/src/utils/github/git.ts
@@ -119,7 +119,7 @@ export function getBranchName(configOrThreadId: GraphConfig | string): string {
     throw new Error("No thread ID provided");
   }
 
-  return `open-swe/${threadId}`;
+  return `agentmojo/${threadId}`;
 }
 
 export async function getChangedFilesStatus(

--- a/apps/open-swe/src/utils/github/issue-messages.ts
+++ b/apps/open-swe/src/utils/github/issue-messages.ts
@@ -105,11 +105,11 @@ export async function getMissingMessages(
   return [...(issueMessage ? [issueMessage] : []), ...untrackedCommentMessages];
 }
 
-export const DEFAULT_ISSUE_TITLE = "New Open SWE Request";
-export const ISSUE_TITLE_OPEN_TAG = "<open-swe-issue-title>";
-export const ISSUE_TITLE_CLOSE_TAG = "</open-swe-issue-title>";
-export const ISSUE_CONTENT_OPEN_TAG = "<open-swe-issue-content>";
-export const ISSUE_CONTENT_CLOSE_TAG = "</open-swe-issue-content>";
+export const DEFAULT_ISSUE_TITLE = "New AgentMojo Request";
+export const ISSUE_TITLE_OPEN_TAG = "<agentmojo-issue-title>";
+export const ISSUE_TITLE_CLOSE_TAG = "</agentmojo-issue-title>";
+export const ISSUE_CONTENT_OPEN_TAG = "<agentmojo-issue-content>";
+export const ISSUE_CONTENT_CLOSE_TAG = "</agentmojo-issue-content>";
 
 export function extractIssueTitleAndContentFromMessage(content: string) {
   let messageTitle: string | null = null;

--- a/apps/open-swe/src/utils/github/issue-task.ts
+++ b/apps/open-swe/src/utils/github/issue-task.ts
@@ -9,11 +9,11 @@ import { createLogger, LogLevel } from "../logger.js";
 import { isLocalMode } from "@open-swe/shared/open-swe/local-mode";
 const logger = createLogger(LogLevel.INFO, "IssueTaskString");
 
-export const TASK_OPEN_TAG = "<open-swe-do-not-edit-task-plan>";
-export const TASK_CLOSE_TAG = "</open-swe-do-not-edit-task-plan>";
+export const TASK_OPEN_TAG = "<agentmojo-do-not-edit-task-plan>";
+export const TASK_CLOSE_TAG = "</agentmojo-do-not-edit-task-plan>";
 
-export const PROPOSED_PLAN_OPEN_TAG = "<open-swe-do-not-edit-proposed-plan>";
-export const PROPOSED_PLAN_CLOSE_TAG = "</open-swe-do-not-edit-proposed-plan>";
+export const PROPOSED_PLAN_OPEN_TAG = "<agentmojo-do-not-edit-proposed-plan>";
+export const PROPOSED_PLAN_CLOSE_TAG = "</agentmojo-do-not-edit-proposed-plan>";
 
 export const DETAILS_OPEN_TAG = "<details>";
 export const DETAILS_CLOSE_TAG = "</details>";

--- a/apps/open-swe/src/utils/github/label.ts
+++ b/apps/open-swe/src/utils/github/label.ts
@@ -1,37 +1,37 @@
 /**
- * @returns "open-swe" or "open-swe-dev" based on the NODE_ENV.
+ * @returns "agentmojo" or "agentmojo-dev" based on the NODE_ENV.
  */
-export function getOpenSWELabel(): "open-swe" | "open-swe-dev" {
-  return process.env.NODE_ENV === "production" ? "open-swe" : "open-swe-dev";
+export function getOpenSWELabel(): "agentmojo" | "agentmojo-dev" {
+  return process.env.NODE_ENV === "production" ? "agentmojo" : "agentmojo-dev";
 }
 
 /**
- * @returns "open-swe-auto" or "open-swe-auto-dev" based on the NODE_ENV.
+ * @returns "agentmojo-auto" or "agentmojo-auto-dev" based on the NODE_ENV.
  */
 export function getOpenSWEAutoAcceptLabel():
-  | "open-swe-auto"
-  | "open-swe-auto-dev" {
+  | "agentmojo-auto"
+  | "agentmojo-auto-dev" {
   return process.env.NODE_ENV === "production"
-    ? "open-swe-auto"
-    : "open-swe-auto-dev";
+    ? "agentmojo-auto"
+    : "agentmojo-auto-dev";
 }
 
 /**
- * @returns "open-swe-max" or "open-swe-max-dev" based on the NODE_ENV.
+ * @returns "agentmojo-max" or "agentmojo-max-dev" based on the NODE_ENV.
  */
-export function getOpenSWEMaxLabel(): "open-swe-max" | "open-swe-max-dev" {
+export function getOpenSWEMaxLabel(): "agentmojo-max" | "agentmojo-max-dev" {
   return process.env.NODE_ENV === "production"
-    ? "open-swe-max"
-    : "open-swe-max-dev";
+    ? "agentmojo-max"
+    : "agentmojo-max-dev";
 }
 
 /**
- * @returns "open-swe-max-auto" or "open-swe-max-auto-dev" based on the NODE_ENV.
+ * @returns "agentmojo-max-auto" or "agentmojo-max-auto-dev" based on the NODE_ENV.
  */
 export function getOpenSWEMaxAutoAcceptLabel():
-  | "open-swe-max-auto"
-  | "open-swe-max-auto-dev" {
+  | "agentmojo-max-auto"
+  | "agentmojo-max-auto-dev" {
   return process.env.NODE_ENV === "production"
-    ? "open-swe-max-auto"
-    : "open-swe-max-auto-dev";
+    ? "agentmojo-max-auto"
+    : "agentmojo-max-auto-dev";
 }

--- a/apps/open-swe/src/utils/github/plan.ts
+++ b/apps/open-swe/src/utils/github/plan.ts
@@ -10,8 +10,8 @@ import { isLocalMode } from "@open-swe/shared/open-swe/local-mode";
 
 const logger = createLogger(LogLevel.INFO, "GitHubPlan");
 
-const PLAN_MESSAGE_OPEN_TAG = "<open-swe-plan-message>";
-const PLAN_MESSAGE_CLOSE_TAG = "</open-swe-plan-message>";
+const PLAN_MESSAGE_OPEN_TAG = "<agentmojo-plan-message>";
+const PLAN_MESSAGE_CLOSE_TAG = "</agentmojo-plan-message>";
 
 function formatBodyWithPlanMessage(body: string, message: string): string {
   if (

--- a/apps/web/src/components/api-key-banner.tsx
+++ b/apps/web/src/components/api-key-banner.tsx
@@ -63,7 +63,7 @@ export function ApiKeyBanner() {
             API Key Required
           </h3>
           <p className="text-sm text-blue-700 dark:text-blue-300">
-            You need to add an API key to use Open SWE. Add your Anthropic,
+            You need to add an API key to use AgentMojo. Add your Anthropic,
             OpenAI, or Google API key to get started.
           </p>
         </div>

--- a/apps/web/src/components/v2/terminal-input.tsx
+++ b/apps/web/src/components/v2/terminal-input.tsx
@@ -255,7 +255,7 @@ export function TerminalInput({
     <div className="border-border bg-muted hover:border-muted-foreground/50 hover:bg-muted/80 focus-within:border-muted-foreground/70 focus-within:bg-muted/80 focus-within:shadow-muted-foreground/20 rounded-md border p-2 font-mono text-xs transition-all duration-200 focus-within:shadow-md">
       <div className="text-foreground flex items-center gap-1">
         <div className="border-border bg-background/50 flex items-center gap-1 rounded-md border p-1 transition-colors duration-200">
-          <span className="text-muted-foreground">open-swe</span>
+          <span className="text-muted-foreground">agentmojo</span>
           <span className="text-muted-foreground/70">@</span>
           <span className="text-muted-foreground">github</span>
         </div>


### PR DESCRIPTION
## Summary
- rename user-visible references from Open SWE to AgentMojo
- update CLI, web UI, and GitHub integration to use AgentMojo labels

## Testing
- `yarn lint:fix`
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68ad1bbd18808321ab8c3c1784d108da